### PR TITLE
Adds some things I added for my home air quality monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea
+/__pycache__/

--- a/aqi.py
+++ b/aqi.py
@@ -40,6 +40,8 @@ def f_estimateAQI(collection):
             # use
             eaqi_honorrific = honorrific
 
+            logger.debug("Found PM2 in Range for {}".format(honorrific))
+
             left = (table["aqilh"] - table["aquil"]) / (table["ch"] - table["cl"])
             right = ((pm25_rounded - table["cl"]))
             eaqi = left * right + table["aqil"]

--- a/aqi.py
+++ b/aqi.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import math
+import logging
+
+#
+# Attempt to Caluculate AQI from Data
+# https://forum.airnowtech.org/t/the-aqi-equation/169
+#
+
+def f_estimateAQI(collection):
+
+    logger = logging.getLogger("f_estimateAQI")
+
+    _pm25_table = {"Good": {"cl": 0.0, "ch": 12.0,
+                            "aqil": 0, "aqih": 50},
+                   "Moderate": {"cl": 12.1, "ch": 35.4,
+                                "aqil": 51, "aqih": 100},
+                   "Unhealthy for Sensitive Groups": {"cl": 35.5, "ch": 55.4,
+                                                      "aqil": 101, "aqih": 150},
+                   "Unhealthy": {"cl": 55.5, "ch": 150.4,
+                                 "aqil": 150.5, "aqih": 250.4},
+                   "Very Unhealthy": {"cl": 150.5, "ch": 250.4,
+                                      "aqil": 201, "aqih": 300},
+                   "Hazardous": {"cl": 250.5, "ch": 500.4,
+                                 "aqil": 301, "aqih": 500}}
+
+    pm25_rounded = math.ceil(collection.pm25_cf1 * 10) / 10
+
+    eaqi = None
+    eaqi_honorrific = None
+
+    if pm25_rounded >= 500.5:
+        eaqi = 501
+        eaqi_honorrific = "Ludicrous"
+
+    for honorrific, table in _pm25_table.items():
+
+        if pm25_rounded >= table["cl"] and pm25_rounded < table["ch"]:
+            # use
+            eaqi_honorrific = honorrific
+
+            left = (table["aqilh"] - table["aquil"]) / (table["ch"] - table["cl"])
+            right = ((pm25_rounded - table["cl"]))
+            eaqi = left * right + table["aqil"]
+
+            break
+        else:
+            continue
+
+    return eaqi, eaqi_honorrific
+
+

--- a/aqi.py
+++ b/aqi.py
@@ -42,7 +42,7 @@ def f_estimateAQI(collection):
 
             logger.debug("Found PM2 in Range for {}".format(honorrific))
 
-            left = (table["aqih"] - table["aquil"]) / (table["ch"] - table["cl"])
+            left = (table["aqih"] - table["aqil"]) / (table["ch"] - table["cl"])
             right = ((pm25_rounded - table["cl"]))
             eaqi = left * right + table["aqil"]
 

--- a/aqi.py
+++ b/aqi.py
@@ -42,7 +42,7 @@ def f_estimateAQI(collection):
 
             logger.debug("Found PM2 in Range for {}".format(honorrific))
 
-            left = (table["aqilh"] - table["aquil"]) / (table["ch"] - table["cl"])
+            left = (table["aqih"] - table["aquil"]) / (table["ch"] - table["cl"])
             right = ((pm25_rounded - table["cl"]))
             eaqi = left * right + table["aqil"]
 

--- a/pms_a003.py
+++ b/pms_a003.py
@@ -1,11 +1,16 @@
 import serial
 import time
+import json
+import logging
 
 
 class PMSReading(object):
     """One single reading."""
 
     def __init__(self, line):
+        self.logger = logging.getLogger("PMSReading")
+        self.logger.debug(line)
+
         self.pm10_cf1 = line[4] * 256 + line[5]
         self.pm25_cf1 = line[6] * 256 + line[7]
         self.pm100_cf1 = line[8] * 256 + line[9]
@@ -18,6 +23,7 @@ class PMSReading(object):
         self.gr25um = line[22] * 256 + line[23]
         self.gr50um = line[24] * 256 + line[25]
         self.gr100um = line[26] * 256 + line[27]
+
 
 
 class SensorException(Exception):

--- a/pms_a003.py
+++ b/pms_a003.py
@@ -11,18 +11,22 @@ class PMSReading(object):
         self.logger = logging.getLogger("PMSReading")
         self.logger.debug(line)
 
-        self.pm10_cf1 = line[4] * 256 + line[5]
-        self.pm25_cf1 = line[6] * 256 + line[7]
-        self.pm100_cf1 = line[8] * 256 + line[9]
-        self.pm10_std = line[10] * 256 + line[11]
-        self.pm25_std = line[12] * 256 + line[13]
-        self.pm100_std = line[14] * 256 + line[15]
-        self.gr03um = line[16] * 256 + line[17]
-        self.gr05um = line[18] * 256 + line[19]
-        self.gr10um = line[20] * 256 + line[21]
-        self.gr25um = line[22] * 256 + line[23]
-        self.gr50um = line[24] * 256 + line[25]
-        self.gr100um = line[26] * 256 + line[27]
+        #
+        # Docs Found Here: https://github.com/adafruit/Adafruit_CircuitPython_PM25/blob/main/adafruit_pm25/__init__.py#L53
+        #
+
+        self.pm10_cf1 = line[4] * 256 + line[5] # PM1.0 μm/m^3 Standard Atmosphere
+        self.pm25_cf1 = line[6] * 256 + line[7] # PM2.5 μm/m^3 Standard Atmosphere
+        self.pm100_cf1 = line[8] * 256 + line[9] # PM10.0 μm/m^3 Standard Atmosphere
+        self.pm10_std = line[10] * 256 + line[11] # PM1.0 μm/m^3 Current Atmosphere
+        self.pm25_std = line[12] * 256 + line[13] # PM2.5 μm/m^3 Current Atmosphere
+        self.pm100_std = line[14] * 256 + line[15] # PM10.0 μm/m^3 Current Atmosphere
+        self.gr03um = line[16] * 256 + line[17] # Particles > 0.3 μm per 0.1L air
+        self.gr05um = line[18] * 256 + line[19] # Particles > 0.5 μm per 0.1L air
+        self.gr10um = line[20] * 256 + line[21] # Particles > 1.0 μm per 0.1L air
+        self.gr25um = line[22] * 256 + line[23] # Particles > 2.5 μm per 0.1L air
+        self.gr50um = line[24] * 256 + line[25] # Particles > 5.0 μm per 0.1L air
+        self.gr100um = line[26] * 256 + line[27] # Particles > 10 μm per 0.1L air
 
 
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Script to Read and Display the Results of a Check
+# Designed to be put in a cron
+
+import argparse
+import logging
+import json
+from os import path
+
+from pms_a003 import Sensor
+from oled_091 import SSD1306
+from time import sleep
+from serial import SerialException
+
+DIR_PATH = path.abspath(path.dirname(__file__))
+DefaultFont = path.join(DIR_PATH, "Fonts/GothamLight.ttf")
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-v", "--verbose", action="append_const", help="Verbosity Controls",
+                        const=1, default=[])
+
+    parser.add_argument("-j", "--json", help="JSON, Write Out", default=None)
+
+    args = parser.parse_args()
+
+    VERBOSE = len(args.verbose)
+
+    if VERBOSE == 0:
+        logging.basicConfig(level=logging.ERROR)
+    elif VERBOSE == 1:
+        logging.basicConfig(level=logging.WARNING)
+    elif VERBOSE == 2:
+        logging.basicConfig(level=logging.INFO)
+    elif VERBOSE > 2:
+        logging.basicConfig(level=logging.DEBUG)
+
+    logger = logging.getLogger("rad_single.py")
+
+    # Initalize Sensor
+    oled_display = SSD1306()
+    air_mon = Sensor()
+    air_mon.connect_hat(port="/dev/ttyS0", baudrate=9600)
+
+
+def info_print():
+    oled_display.DirImage(path.join(DIR_PATH, "Images/SB.png"))
+    oled_display.DrawRect()
+    oled_display.ShowImage()
+    sleep(1)
+    oled_display.PrintText("  Waiting....", FontSize=14)
+    oled_display.ShowImage()
+
+    try:
+        values = air_mon.read()
+
+        jsonic_data = dict(pm1_0=values.pm10_cf1,
+                           pm2_5=values.pm25_cf1,
+                           pm10=values.pm100_cf1)
+
+
+        oled_display.PrintText("PM1.0= {:2d}".format(values.pm10_cf1),
+                               cords=(2, 2), FontSize=10)
+        oled_display.PrintText("PM2.5= {:2d}".format(values.pm25_cf1),
+                               cords=(65, 2), FontSize=10)
+        oled_display.PrintText("PM10= {:2d}".format(values.pm100_cf1),
+                               cords=(25, 20), FontSize=13)
+        oled_display.ShowImage()
+
+    except KeyboardInterrupt:
+        air_mon.disconnect_hat()
+    else:
+
+        if args.json:
+            logger.debug("Implement Write Out Feature Set.")
+
+        logger.debug(json.dumps(jsonic_data))
+

--- a/rad_single.py
+++ b/rad_single.py
@@ -65,6 +65,8 @@ def info_print():
         logger.debug("pn2.5 Std Dev: {}".format(values.pm25_std))
         logger.debug("pm10.0 Std Dev: {}".format(values.pm100_std))
         logger.debug("Ozone : {}".format(values.gr25um))
+        logger.debug("Unknown: {}".format(values.gr10um))
+        logger.debug("Unknown: {}".format(values.gr100um))
 
 
         oled_display.PrintText("PM1.0= {:2d}".format(values.pm10_cf1),

--- a/rad_single.py
+++ b/rad_single.py
@@ -32,6 +32,9 @@ def collect_data(max=5):
             values = air_mon.read()
         except SerialException as se:
             logger.error("Serial Exception found when requesting Data: {}".format(se))
+        except Exception as gen_err:
+            logger.error("General Error: {} {}".format(type(gen_err), gen_err))
+            break
         else:
             # It worked Break Out
             break

--- a/rad_single.py
+++ b/rad_single.py
@@ -84,7 +84,7 @@ def info_print(oled_display):
                                cords=(2, 2), FontSize=10)
         oled_display.PrintText("PM2.5= {:2d}".format(values.pm25_cf1),
                                cords=(65, 2), FontSize=10)
-        oled_display.PrintText("AQI= {:2d}".format(eaqi),
+        oled_display.PrintText("AQI= {:2f}".format(eaqi),
                                cords=(25, 20), FontSize=13)
         oled_display.ShowImage()
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -58,8 +58,8 @@ def info_print():
                            pm10=values.pm100_cf1)
 
         logger.debug(jsonic_data)
-        logger.debug(values.pm25_std)
-        logger.debug(values.gr25um)
+        logger.debug("pn2.5 Standard Deviation : {}".format(values.pm25_std))
+        logger.debug("Ozone : {}".format(values.gr25um))
 
 
         oled_display.PrintText("PM1.0= {:2d}".format(values.pm10_cf1),

--- a/rad_single.py
+++ b/rad_single.py
@@ -85,7 +85,7 @@ def info_print(oled_display):
                                cords=(2, 2), FontSize=10)
         oled_display.PrintText("PM2.5= {:2d}".format(values.pm25_cf1),
                                cords=(65, 2), FontSize=10)
-        oled_display.PrintText("AQI= {:2f}".format(eaqi),
+        oled_display.PrintText("AQI= {:.2f}".format(eaqi),
                                cords=(25, 20), FontSize=13)
         oled_display.ShowImage()
 
@@ -148,11 +148,11 @@ if __name__ == "__main__":
         else:
 
             if info["data"]["pm2_5"] > threshold_high:
-                msg = "Critical - Air Quality {eaqi_h} ({eaqi:2f})".format(**info)
+                msg = "Critical - Air Quality {eaqi_h} ({eaqi:.2f})".format(**info)
             elif info["data"]["pm2_5"] > threshold_moderate:
-                msg = "Warning - Air Quality {eaqi_h} ({eaqi:2f})".format(**info)
+                msg = "Warning - Air Quality {eaqi_h} ({eaqi:.2f})".format(**info)
             else:
-                msg = "OK - Air Quality {eaqi_h} ({eaqi:2f})".format(**info)
+                msg = "OK - Air Quality {eaqi_h} ({eaqi:.2f})".format(**info)
 
         perf_data = " ".join(["{}={}".format(k, v) for k, v in info["data"].items()])
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -67,6 +67,7 @@ def info_print(oled_display):
         values = collect_data()
 
         eaqi, info["eaqi_h"] = f_estimateAQI(values)
+        info["eaqi"] = eaqi
 
 
         jsonic_data = dict(pm1_0=values.pm10_cf1,
@@ -147,11 +148,11 @@ if __name__ == "__main__":
         else:
 
             if info["data"]["pm2_5"] > threshold_high:
-                msg = "Critical - Air Quality {eaqi_h} ({data['eaqi']:2f})".format(**info)
+                msg = "Critical - Air Quality {eaqi_h} ({eaqi:2f})".format(**info)
             elif info["data"]["pm2_5"] > threshold_moderate:
-                msg = "Warning - Air Quality {eaqi_h} ({data['eaqi']:2f})".format(**info)
+                msg = "Warning - Air Quality {eaqi_h} ({eaqi:2f})".format(**info)
             else:
-                msg = "OK - Air Quality {eaqi_h} ({data['eaqi']:2f})".format(**info)
+                msg = "OK - Air Quality {eaqi_h} ({eaqi:2f})".format(**info)
 
         perf_data = " ".join(["{}={}".format(k, v) for k, v in info["data"].items()])
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -51,7 +51,7 @@ def collect_data(max=5):
 
 
 
-def info_print(oled_display, ari_mon):
+def info_print(oled_display):
     oled_display.DirImage(path.join(DIR_PATH, "Images/SB.png"))
     oled_display.DrawRect()
     oled_display.ShowImage()

--- a/rad_single.py
+++ b/rad_single.py
@@ -149,10 +149,13 @@ if __name__ == "__main__":
 
             if info["data"]["pm2_5"] > threshold_high:
                 msg = "Critical - Air Quality {eaqi_h} ({eaqi:.2f})".format(**info)
+                return_code = 2
             elif info["data"]["pm2_5"] > threshold_moderate:
                 msg = "Warning - Air Quality {eaqi_h} ({eaqi:.2f})".format(**info)
+                return_code = 1
             else:
                 msg = "OK - Air Quality {eaqi_h} ({eaqi:.2f})".format(**info)
+                return_code = 0
 
         perf_data = " ".join(["{}={}".format(k, v) for k, v in info["data"].items()])
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -6,6 +6,7 @@
 import argparse
 import logging
 import json
+import time
 from os import path
 
 from pms_a003 import Sensor
@@ -16,14 +17,24 @@ from serial import SerialException
 DIR_PATH = path.abspath(path.dirname(__file__))
 DefaultFont = path.join(DIR_PATH, "Fonts/GothamLight.ttf")
 
-def collect_data():
+def collect_data(max=5):
     air_mon = Sensor()
     air_mon.connect_hat(port="/dev/ttyS0", baudrate=9600)
 
-    values = air_mon.read()
-    logger.debug("PMS 1 value is {}".format(values.pm10_cf1))
-    logger.debug("PMS 2.5 value is {}".format(values.pm25_cf1))
-    logger.debug("PMS 10 value is {}".format(values.pm100_cf1))
+    values = None
+
+    for x in range(0, max):
+        if x > 0:
+            logger.debug("Retrying Attempt {}".format(x))
+            time.sleep(3)
+
+        try:
+            values = air_mon.read()
+        except SerialException as se:
+            logger.error("Serial Exception found when requesting Data: {}".format(se))
+        else:
+            # It worked Break Out
+            break
 
     air_mon.disconnect_hat()
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -18,6 +18,9 @@ from serial import SerialException
 DIR_PATH = path.abspath(path.dirname(__file__))
 DefaultFont = path.join(DIR_PATH, "Fonts/GothamLight.ttf")
 
+threshold_moderate = 13
+threshold_high = 36
+
 def collect_data(max=5):
     air_mon = Sensor()
     air_mon.connect_hat(port="/dev/ttyS0", baudrate=9600)
@@ -122,5 +125,27 @@ if __name__ == "__main__":
     #air_mon.connect_hat(port="/dev/ttyS0", baudrate=9600)
 
     info = info_print(oled_display)
+
+
+    if args.nrpe is True:
+        msg = "Unknown - I don't know what has happened"
+        return_code = 3
+        # I have a nrpe request
+        if info["okay"] is False:
+            msg = "Error - I have had a significant error and I do not know why."
+            return_code = 3
+        else:
+
+            if info["data"]["pm2_5"] > threshold_high:
+                msg = "Critical - Bad Air Quality Detected"
+            elif info["data"]["pm2_5"] > threshold_moderate:
+                msg = "Warning - Suboptimal Air Quality Detected"
+            else:
+                msg = "OK - Air Quality Okay"
+
+        perf_data = " ".join(["{k}={v}".format(k, v) for k, v in info["data"].items()])
+
+        print("{} | {}".format(msg, perf_data))
+
 
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -70,8 +70,9 @@ def info_print():
                                cords=(25, 20), FontSize=13)
         oled_display.ShowImage()
 
-    except KeyboardInterrupt:
+    except Exception as e:
         air_mon.disconnect_hat()
+        logger.error("Error Reading From Sensor : {}".format(e))
     else:
 
         if args.json:

--- a/rad_single.py
+++ b/rad_single.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             else:
                 msg = "OK - Air Quality Okay"
 
-        perf_data = " ".join(["{k}={v}".format(k, v) for k, v in info["data"].items()])
+        perf_data = " ".join(["{}={}".format(k, v) for k, v in info["data"].items()])
 
         print("{} | {}".format(msg, perf_data))
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -61,7 +61,9 @@ def info_print():
                            pm10=values.pm100_cf1)
 
         logger.debug(jsonic_data)
-        logger.debug("pn2.5 Standard Deviation : {}".format(values.pm25_std))
+        logger.debug("pn10 Std Dev: {}".format(values.pm10_std))
+        logger.debug("pn2.5 Std Dev: {}".format(values.pm25_std))
+        logger.debug("pm10.0 Std Dev: {}".format(values.pm100_std))
         logger.debug("Ozone : {}".format(values.gr25um))
 
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.DEBUG)
 
     logger = logging.getLogger("rad_single.py")
+    logger.info("Running rad_single.py")
 
     # Initalize Sensor
     oled_display = SSD1306()

--- a/rad_single.py
+++ b/rad_single.py
@@ -147,11 +147,11 @@ if __name__ == "__main__":
         else:
 
             if info["data"]["pm2_5"] > threshold_high:
-                msg = "Critical - Air Quality {eaqi_h} ({data['eaqi']})".format(**info)
+                msg = "Critical - Air Quality {eaqi_h} ({data['eaqi']:2f})".format(**info)
             elif info["data"]["pm2_5"] > threshold_moderate:
-                msg = "Warning - Air Quality {eaqi_h} ({data['eaqi']})".format(**info)
+                msg = "Warning - Air Quality {eaqi_h} ({data['eaqi']:2f})".format(**info)
             else:
-                msg = "OK - Air Quality {eaqi_h} ({data['eaqi']})".format(**info)
+                msg = "OK - Air Quality {eaqi_h} ({data['eaqi']:2f})".format(**info)
 
         perf_data = " ".join(["{}={}".format(k, v) for k, v in info["data"].items()])
 

--- a/rad_single.py
+++ b/rad_single.py
@@ -47,6 +47,8 @@ def info_print():
                            pm10=values.pm100_cf1)
 
         logger.debug(jsonic_data)
+        logger.debug(values.pm25_std)
+        logger.debug(values.gr25um)
 
 
         oled_display.PrintText("PM1.0= {:2d}".format(values.pm10_cf1),

--- a/rad_single.py
+++ b/rad_single.py
@@ -9,6 +9,7 @@ import json
 import time
 from os import path
 
+import pms_a003
 from pms_a003 import Sensor
 from oled_091 import SSD1306
 from time import sleep
@@ -32,6 +33,8 @@ def collect_data(max=5):
             values = air_mon.read()
         except SerialException as se:
             logger.error("Serial Exception found when requesting Data: {}".format(se))
+        except pms_a003.SensorException as sensor_exception:
+            logger.error("Sensor Exception : {}".format(sensor_exception))
         except Exception as gen_err:
             logger.error("General Error: {} {}".format(type(gen_err), gen_err))
             break
@@ -61,13 +64,6 @@ def info_print():
                            pm10=values.pm100_cf1)
 
         logger.debug(jsonic_data)
-        logger.debug("pn10 Std Dev: {}".format(values.pm10_std))
-        logger.debug("pn2.5 Std Dev: {}".format(values.pm25_std))
-        logger.debug("pm10.0 Std Dev: {}".format(values.pm100_std))
-        logger.debug("Ozone : {}".format(values.gr25um))
-        logger.debug("Unknown: {}".format(values.gr10um))
-        logger.debug("Unknown: {}".format(values.gr100um))
-
 
         oled_display.PrintText("PM1.0= {:2d}".format(values.pm10_cf1),
                                cords=(2, 2), FontSize=10)

--- a/rad_single.py
+++ b/rad_single.py
@@ -147,11 +147,11 @@ if __name__ == "__main__":
         else:
 
             if info["data"]["pm2_5"] > threshold_high:
-                msg = "Critical - Bad Air Quality Detected ({eaqi_h})".format(**info)
+                msg = "Critical - Air Quality {eaqi_h} ({data['eaqi']})".format(**info)
             elif info["data"]["pm2_5"] > threshold_moderate:
-                msg = "Warning - Suboptimal Air Quality Detected ({eaqi_h})".format(**info)
+                msg = "Warning - Air Quality {eaqi_h} ({data['eaqi']})".format(**info)
             else:
-                msg = "OK - Air Quality Okay ({eaqi_h})".format(**info)
+                msg = "OK - Air Quality {eaqi_h} ({data['eaqi']})".format(**info)
 
         perf_data = " ".join(["{}={}".format(k, v) for k, v in info["data"].items()])
 


### PR DESCRIPTION
* Adds some code documentation based on an [adafruit module using the same pmsa003 chip](https://github.com/adafruit/Adafruit_CircuitPython_PM25/blob/main/adafruit_pm25/__init__.py#L53). #1 
* Adds an AQI estimator based on the [AQI Calulation](https://forum.airnowtech.org/t/the-aqi-equation/169).
* Adds `rad_single.py` a script to pull the readings "just once".
  * rad = Read Air Device
  * Will update LCD with data.
  * Also has a [nrpe mode](https://github.com/NagiosEnterprises/nrpe) that allows the output to match the Nagios check output format. This can allow you to monitor your air quality in a Nagios or Nagios compatible (think zabbix) monitoring system.